### PR TITLE
Add support for multiple compilation standards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -59,6 +59,14 @@
             <input type="checkbox" value="1" name="optimize"/> Optimize (-O2) works only with simple code</label>
             <label class="checkbox"><input type="checkbox" value="1" name="arm"/> Use ARM</label>
             <label class="checkbox"><input type="checkbox" value="1" name="intel_asm"/> Use Intel ASM</label>
+            <label>
+                Compilation standard
+                <select name="standard">
+                    <option value="c99">c99</option>
+                    <option value="c++11">c++11</option>
+                    <option value="c++14">c++14</option>
+                </select>
+            </label>
         </form>
         <button id="compile" class="btn btn-primary btn-large" data-loading-text="Code is compiling..." autocomplete="off">Translate Code to Assembly</button>
     </div>

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -67,13 +67,24 @@ exports.indexpost = (req, res)->
 	compiler=if req.body.arm then "arm-linux-gnueabi-g++-4.6" else "gcc"
 	asm=if req.body.intel_asm then "-masm=intel" else ""
 	
+	allowedstandards = [
+		'c++11'
+		'c++14'
+		'c99'
+	]
+	
+	if allowedstandards.indexOf(req.body.standard) > -1
+		standard = req.body.standard
+	else
+		standard = 'c99'
+	
 	#Write input to file
 	fs.writeFile "/tmp/test#{fileid}.#{lang}", req.body.ccode, (err)->
 		if err
 			res.json({error:"Server Error"});
 		else
 			# Execute GCC
-			exec "c-preload/compiler-wrapper #{compiler} #{asm} -std=c99 -c #{optimize} -Wa,-ald  -g /tmp/test#{fileid}.#{lang}", {timeout:10000,maxBuffer: 1024 * 1024*10}, (error, stdout, stderr)->
+			exec "c-preload/compiler-wrapper #{compiler} #{asm} -std=#{standard} -c #{optimize} -Wa,-ald  -g /tmp/test#{fileid}.#{lang}", {timeout:10000,maxBuffer: 1024 * 1024*10}, (error, stdout, stderr)->
 					if error?
 						#Send error message to the client
 						res.json({error:error.toString()});


### PR DESCRIPTION
This adds support for `c++14` and `c++11` during compilation via a dropdown on the page. They are explicitly whitelisted with a fallback to `c99` in case of (possibly malicious) unexpected input.

Practically all instances of `gcc` and `g++` support this.

This resolves #5.