### PR TITLE
Fix linting and typos

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -1,41 +1,36 @@
 cluster = require('cluster')
-numCPUs = require('os').cpus().length;
+numCPUs = require('os').cpus().length
 
 if cluster.isMaster
   for i in [1..numCPUs]
-    cluster.fork();
+    cluster.fork()
 else
-
   express = require('express')
   routes = require('./routes')
   http = require('http')
   path = require('path')
 
-  app = express();
+  app = express()
 
   app.configure ()->
-    app.set('port', process.env.PORT || 8080);
-    app.set('views', __dirname + '/views');
-    app.set('view engine', 'ejs');
-    app.use(express.favicon());
-  #  app.use(express.logger('dev'));
-    app.use(express.bodyParser());
-    app.use(express.methodOverride());
-    app.use(express.cookieParser('your secret here'));
-    app.use(express.session());
-    app.use(app.router);
-    app.use(require('stylus').middleware(__dirname + '/public'));
-    app.use(express.static(path.join(__dirname, 'public')));
+    app.set('port', process.env.PORT || 8080)
+    app.set('views', __dirname + '/views')
+    app.set('view engine', 'ejs')
+    app.use(express.favicon())
+  # app.use(express.logger('dev'))
+    app.use(express.bodyParser())
+    app.use(express.methodOverride())
+    app.use(express.cookieParser('your secret here'))
+    app.use(express.session())
+    app.use(app.router)
+    app.use(require('stylus').middleware(__dirname + '/public'))
+    app.use(express.static(path.join(__dirname, 'public')))
     app.use routes.error404
-
 
   #app.configure 'development', ()->
   #  app.use(express.errorHandler())
 
- 
   app.post '/compile', routes.indexpost
 
-
   http.createServer(app).listen app.get('port'), ()->
-    console.log("Express server listening on port " + app.get('port'));
-   
+    console.log("Express server listening on port " + app.get('port'))

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -1,7 +1,7 @@
 fs = require('fs')
-util = require('util');
+util = require('util')
 
-exec = require('child_process').exec;
+exec = require('child_process').exec
 decodeCode=(asm,code)->
 	#split input
 	asm_lines = asm.split("\n")
@@ -13,7 +13,7 @@ decodeCode=(asm,code)->
 	readmode=false
 	currentline=0
 	for asline in asm_lines
-		
+
 		linedata=/^[ ]+[0-9]+ (.*)/m.exec(asline)
 		if linedata?
 			#parse file start markers '.file "filename"'
@@ -35,16 +35,16 @@ decodeCode=(asm,code)->
 						if currentlabel? and currentlabel < 1
 							delete label_data[currentlabel]
 
-						labels[label[1]]= 0 
-						label_data[label[1]]= {0:linedata[1]+"\n"} 
-						currentlabel=label[1];
+						labels[label[1]]= 0
+						label_data[label[1]]= {0:linedata[1]+"\n"}
+						currentlabel=label[1]
 				else if currentlabel?
 					#parse .loc
 					loc= /^[ \t]*.loc ([0-9]+) ([0-9]+)/.exec(linedata[1])
 					if loc?
 						readmode=files[parseInt(loc[1])]
 						currentline=if readmode then parseInt(loc[2]) else 0
-					else 
+					else
 						if not label_data[currentlabel][currentline]?
 							label_data[currentlabel][currentline]=""
 						label_data[currentlabel][currentline]+= linedata[1]+"\n"
@@ -57,37 +57,38 @@ decodeCode=(asm,code)->
 
 exports.error404 = (req, res)->
   res.status(404)
-  res.render('404', { title: 'C/C++ to Assembly' });
+  res.render('404', { title: 'C/C++ to Assembly' })
 
 exports.indexpost = (req, res)->
 	optimize=if req.body.optimize? then "-O2" else ""
 	lang=if req.body.language=="c" then "c" else "cpp"
 	#Generate file name
-	fileid=Math.floor(Math.random()*1000000001);
+	fileid=Math.floor(Math.random()*1000000001)
 	compiler=if req.body.arm then "arm-linux-gnueabi-g++-4.6" else "gcc"
 	asm=if req.body.intel_asm then "-masm=intel" else ""
-	
+
 	#Write input to file
 	fs.writeFile "/tmp/test#{fileid}.#{lang}", req.body.ccode, (err)->
 		if err
-			res.json({error:"Server Error"});
+			res.json({error:"Server Error"})
 		else
 			# Execute GCC
-			exec "c-preload/compiler-wrapper #{compiler} #{asm} -std=c99 -c #{optimize} -Wa,-ald  -g /tmp/test#{fileid}.#{lang}", {timeout:10000,maxBuffer: 1024 * 1024*10}, (error, stdout, stderr)->
+			compilecmd = "c-preload/compiler-wrapper #{compiler} #{asm} " +
+										"-std=c99 -c #{optimize} -Wa,-ald " +
+										"-g /tmp/test#{fileid}.#{lang}"
+			exec compilecmd,
+					{timeout:10000,maxBuffer: 1024 * 1024*10},
+					(error, stdout, stderr)->
 					if error?
 						#Send error message to the client
-						res.json({error:error.toString()});
+						res.json({error:error.toString()})
 						fs.unlink("/tmp/test#{fileid}.#{lang}")
 						fs.unlink("test#{fileid}.o")
 					else
 						#Parse standart output
 						blocks=decodeCode(stdout,req.body.ccode)
-						#Send result as json to the clien 
-						res.json(blocks);
+						#Send result as json to the clien
+						res.json(blocks)
 						#Clean up
 						fs.unlink("/tmp/test#{fileid}.#{lang}")
 						fs.unlink("test#{fileid}.o")
-
-
-
-

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -87,10 +87,12 @@ exports.indexpost = (req, res)->
 						fs.unlink("/tmp/test#{fileid}.#{lang}")
 						fs.unlink("test#{fileid}.o")
 					else
-						#Parse standart output
+						#Parse standard output
 						blocks=decodeCode(stdout,req.body.ccode)
+
 						#Send result as json to the client
 						res.json(blocks)
+						
 						#Clean up
 						fs.unlink("/tmp/test#{fileid}.#{lang}")
 						fs.unlink("test#{fileid}.o")

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -72,7 +72,7 @@ exports.indexpost = (req, res)->
 	#Write input to file
 	fs.writeFile "/tmp/test#{fileid}.#{lang}", req.body.ccode, (err)->
 		if err
-			res.json({error:"Server Error: unable to write to temp directory"});
+			res.json({error:"Server Error: unable to write to temp directory"})
 		else
 			# Execute GCC
 			compilecmd = "c-preload/compiler-wrapper #{compiler} #{asm} " +

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -89,7 +89,7 @@ exports.indexpost = (req, res)->
 					else
 						#Parse standart output
 						blocks=decodeCode(stdout,req.body.ccode)
-						#Send result as json to the clien
+						#Send result as json to the client
 						res.json(blocks)
 						#Clean up
 						fs.unlink("/tmp/test#{fileid}.#{lang}")

--- a/routes/index.coffee
+++ b/routes/index.coffee
@@ -12,8 +12,8 @@ decodeCode=(asm,code)->
 	files=[]
 	readmode=false
 	currentline=0
-	for asline in asm_lines
 
+	for asline in asm_lines
 		linedata=/^[ ]+[0-9]+ (.*)/m.exec(asline)
 		if linedata?
 			#parse file start markers '.file "filename"'
@@ -50,6 +50,7 @@ decodeCode=(asm,code)->
 						label_data[currentlabel][currentline]+= linedata[1]+"\n"
 						if readmode
 							labels[currentlabel]++
+
 	if currentlabel? and currentlabel < 1
 		delete label_data[currentlabel]
 	{code:code_lines,asm:label_data}
@@ -62,6 +63,7 @@ exports.error404 = (req, res)->
 exports.indexpost = (req, res)->
 	optimize=if req.body.optimize? then "-O2" else ""
 	lang=if req.body.language=="c" then "c" else "cpp"
+
 	#Generate file name
 	fileid=Math.floor(Math.random()*1000000001)
 	compiler=if req.body.arm then "arm-linux-gnueabi-g++-4.6" else "gcc"


### PR DESCRIPTION
Perform linting to coffeelint spec. This has not addressed indenting! I've got a branch to do that (convert indents to spaces) but I know that's a cantankerous issues (although I think spaces have been mostly settled on, plus it brings the code into full spec with `coffeelint`) so I have a separate issue for that (issue #8).